### PR TITLE
[Dependencies] Changed cargo.toml to use crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,26 +6,11 @@ authors = ["Antoni Boucher <bouanto@zoho.com>"]
 [dependencies]
 bitflags = "^0.7"
 libc = "^0.2"
-
-[dependencies.gio-sys]
-git = "https://github.com/gtk-rs/sys"
-version = "0.3.1"
-
-[dependencies.glib]
-git = "https://github.com/gtk-rs/glib"
-version = "0.1.0"
-
-[dependencies.glib-sys]
-git = "https://github.com/gtk-rs/sys"
-version = "0.3.1"
-
-[dependencies.gobject-sys]
-git = "https://github.com/gtk-rs/sys"
-version = "0.3.1"
-
-[dependencies.gtk]
-git = "https://github.com/gtk-rs/gtk"
-version = "0.1.0"
+gio-sys = "0.3.1"
+glib = "0.1.0"
+glib-sys = "0.3.1"
+gobject-sys = "0.3.1"
+gtk = "0.1.0"
 
 [dependencies.secret-sys]
 git = "https://github.com/antoyo/secret-sys-rs"


### PR DESCRIPTION
This uses crates.io so that old versions of the packages are
available. When only pointing to the git repo, it seems you are stuck
at what ever the master version is on at the time.

This would be dependent on: https://github.com/antoyo/secret-sys-rs/pull/1